### PR TITLE
Single output feed for group chat

### DIFF
--- a/scripts/python/pss/agent.py
+++ b/scripts/python/pss/agent.py
@@ -42,7 +42,7 @@ class Agent:
 		select.select([], [self.sock], [], REQUEST_TIMEOUT)
 		os.write(self.sock, requeststring)
 		select.select([self.sock], [], [], REQUEST_TIMEOUT)
-		r = os.read(self.sock, 1024)
+		r = os.read(self.sock, 4104)
 		m = regexStatusLine.match(r)
 		if m.group(1) != "200":
 			print r

--- a/scripts/python/pss/tools.py
+++ b/scripts/python/pss/tools.py
@@ -57,7 +57,15 @@ def clean_nick(s):
 		raise ValueError("invalid characters in nick")
 
 	return s.encode("ascii")	
-	
+
+
+
+def clean_name(s):
+	name = clean_nick(s)
+	if len(name) > 20:
+		raise ValueError("name too long")
+
+	return name	
 	
 
 

--- a/scripts/python/pss/user.py
+++ b/scripts/python/pss/user.py
@@ -61,9 +61,15 @@ class Account:
 
 
 	def _clear_key(self):
-		self.privkatekey = None
+		self.privatekey = None
 		self.publickeybytes = ""
 		self.address = None
+
+
+
+	def is_owner(self):
+		return self.privatekey != None
+			
 
 
 def publickey_to_account(keybytes):

--- a/scripts/python/pss/user.py
+++ b/scripts/python/pss/user.py
@@ -28,9 +28,15 @@ class PssContact:
 		self.address = "0x" + validaddr
 		self.src = src
 
+
 	# \todo proper nested json serialize
 	def serialize(self):
 		return	"\"key\":\"" + self.key + "\""
+
+
+	# \todo implement	
+	def encrypt_to(self, s):
+		return s
 
 
 # holds ethereum account

--- a/scripts/python/pss/user.py
+++ b/scripts/python/pss/user.py
@@ -41,6 +41,7 @@ class PssContact:
 
 # holds ethereum account
 # \todo move out of pss to enable sync comms even though crypto modules doesn't exist
+# \todo simplify representation of public key with 04 byte prefix
 class Account:
 	privatekey = None
 	publickeybytes = "" 
@@ -55,7 +56,7 @@ class Account:
 
 	def set_public_key(self, pubkey):
 		self._clear_key()
-		self.publickeybytes = pubkey
+		self.publickeybytes = pubkey[1:]
 		self.address = publickey_to_account(self.publickeybytes[1:])
 	
 	

--- a/scripts/python/serialize_test.py
+++ b/scripts/python/serialize_test.py
@@ -50,12 +50,13 @@ class TestSerialize(unittest.TestCase):
 
 	def test_room(self):
 		acc = pss.Account()
+		print len(self.pubkey[0])
 		acc.set_public_key(self.pubkey[0].decode("hex"))
 		feed = pss.Feed(None, acc, "root", False)
 		r = pss.Room(None, feed)
-		r.set_name("foo")
+		#r.start("bar", "foo")
 		for i in range(len(self.pubkey)):
-			r.add(str(i), Participant(str(i), self.pubkey[i], self.addr[i], self.nodekey[i]))
+			r.participants[str(i)] = Participant(str(i), self.pubkey[i], self.addr[i], self.nodekey[i])
 
 		s = r.serialize()
 		try:

--- a/scripts/python/singlepss.py
+++ b/scripts/python/singlepss.py
@@ -259,7 +259,8 @@ def buf_get(pssName, typ, name, known):
 			bufs[bufname] = buf
 			
 			feeds[bufname] = pss.Feed(bzzs[pssName].agent, psses[pssName].get_account(), PSS_BUFTYPE_ROOM + pss.publickey_to_account(psses[pssName].key[2:].decode("hex")))
-			rooms[name] = pss.Room(name, bzzs[pssName].agent, feeds[bufname])
+			rooms[name] = pss.Room(bzzs[pssName], feeds[bufname])
+			rooms[name].start("me", name)
 			wOut(PSS_BUFPFX_DEBUG, [], "", "added room feed with topic " + feeds[bufname].topic.encode("hex"))
 
 		else:


### PR DESCRIPTION
This PR concatenates outputs per participants to all participants in one single feed. The feed update now include metadata header. Given `p` as participant count, structure is as follows:

* header
    - 32 bytes swarm hash pointing to room state at time of update
    - `p` number of 24 bit byte offset values pointing to respective participant's data in body

* body
    - tightly packed payload data, respectively per participant

If at time of read of update, the reader's instance's room state hash does not match the one retrieved, the room state must be retrieved before contents are parsed.